### PR TITLE
Adds `null` to the internal list.

### DIFF
--- a/Ve/ruleset.xml
+++ b/Ve/ruleset.xml
@@ -30,6 +30,9 @@
 		<exclude name="Ve.Commenting.FunctionComment.MissingReturn"/>
 		<exclude name="Ve.Commenting.FunctionComment.MissingParamTag"/>
 		<exclude name="Ve.Commenting.FunctionComment.EmptyThrows"/>
+		<properties>
+			<property name="treatNullAsInternalType" value="1"/>
+		</properties>
 	</rule>
 	<rule ref="Squiz.Commenting.FunctionCommentThrowTag" />
 	<rule ref="Squiz.Commenting.ClassComment">
@@ -43,7 +46,7 @@
 		<properties>
 			<property name="spacing" value="1"/>
 			<property name="ignoreNewlines" value="true"/>
-	   </properties>
+		</properties>
 	</rule>
 	<rule ref="Squiz.Classes.ClassFileName"/>
 	<rule ref="Ve.Classes.AbstractClassName"/>


### PR DESCRIPTION
 * Add `null` as a toggleable internal type. This allows `null` to be used as a type-check without requiring it in the function signature.
 * Fixes #2.